### PR TITLE
TaskChunk: Clear prefetched cache of task on every update to fix

### DIFF
--- a/task/serializers.py
+++ b/task/serializers.py
@@ -163,8 +163,6 @@ class TaskChunkSerializer(serializers.ModelSerializer):
                 if duration_delta:
                     instance.task.duration += duration_delta
                     instance.task.save()
-                    if hasattr(instance.task, '_prefetched_objects_cache'):
-                        del instance.task._prefetched_objects_cache
 
             new_day = validated_data.get('day')
             if new_day and new_day != instance.day:
@@ -184,5 +182,8 @@ class TaskChunkSerializer(serializers.ModelSerializer):
                     exchange = exchange[0]
                     exchange.day_order = instance.day_order
                     exchange.save(update_fields=('day_order',))
+
+            if hasattr(instance.task, '_prefetched_objects_cache'):
+                del instance.task._prefetched_objects_cache
 
             return super().update(instance, validated_data)

--- a/task/tests.py
+++ b/task/tests.py
@@ -904,6 +904,15 @@ class TaskChunkViewSetTest(AuthenticatedApiTest):
         self.assertEqual(
             resp.status_code,
             status.HTTP_200_OK)
+        self.assertEqual(
+            Decimal(resp.data['task']['duration']),
+            Decimal(2))
+        self.assertEqual(
+            Decimal(resp.data['task']['scheduled_duration']),
+            Decimal(1))
+        self.assertEqual(
+            Decimal(resp.data['task']['finished_duration']),
+            Decimal(1))
 
         task_chunk.refresh_from_db()
         self.assertEqual(
@@ -929,6 +938,15 @@ class TaskChunkViewSetTest(AuthenticatedApiTest):
         self.assertEqual(
             resp.status_code,
             status.HTTP_200_OK)
+        self.assertEqual(
+            Decimal(resp.data['task']['duration']),
+            Decimal(2))
+        self.assertEqual(
+            Decimal(resp.data['task']['scheduled_duration']),
+            Decimal(1))
+        self.assertEqual(
+            Decimal(resp.data['task']['finished_duration']),
+            Decimal(0))
 
         task_chunk.refresh_from_db()
         self.assertEqual(


### PR DESCRIPTION
inconsistent finished_duration